### PR TITLE
Fix typo

### DIFF
--- a/lib/skp/cli.rb
+++ b/lib/skp/cli.rb
@@ -234,7 +234,7 @@ module SKP
         say "You can check it out now, or to continue: $ skp next "
       when "prof_gray"
         say "Sidekiq in Practice has several hands-on labs to help you to understand the workshop."
-        say "We've downlaoded some supporting files in ./prof_gray"
+        say "We've downloaded some supporting files in ./prof_gray"
         say "You will need to read these files to work on the labs, but don't modify them."
         say "You can check them out now, or to continue: $ skp next "
       end


### PR DESCRIPTION
Found a small typo that says _downlaoded_ instead of _downloaded_. This PR fixes it.